### PR TITLE
Remove deprecated config options from mongod.conf to support mongodb 3.6

### DIFF
--- a/habitat/config/mongod.conf
+++ b/habitat/config/mongod.conf
@@ -57,12 +57,6 @@ net:
       pathPrefix: {{pkg.svc_files_path}}/tmp
       filePermissions: {{cfg.mongod.net.unix_domain_socket.file_permissions}}
 
-net:
-   http:
-      enabled: {{cfg.mongod.net.http.enabled}}
-      JSONPEnabled: {{cfg.mongod.net.http.jsonp_enabled}}
-      RESTInterfaceEnabled: {{cfg.mongod.net.http.rest_interface_enabled}}
-
 {{~#if cfg.mongod.net.ssl.enabled}}
 net:
    ssl:

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,6 +1,6 @@
 pkg_origin=echohack
 pkg_name=np-mongodb
-pkg_version=3.2.9
+pkg_version=3.6.4
 pkg_description="Mongodb for National-Parks app"
 pkg_maintainer="echohack"
 pkg_license=('AGPL-3.0')


### PR DESCRIPTION
Mongo 3.6 was failing to start with the net.http config section.  Support for these options was deprecated in 3.4, and removed from 3.6